### PR TITLE
Add leaderboard auto-update every 4 hours and delete existing leaderboard messages

### DIFF
--- a/src/commands/valleaderboard.js
+++ b/src/commands/valleaderboard.js
@@ -25,6 +25,13 @@ async function handleValLeaderboard(msg) {
 
         const channel = msg.guild.channels.cache.find(ch => ch.name === 'newb-ranking');
 
+        // Delete all existing leaderboard messages in the channel
+        const messages = await channel.messages.fetch();
+        const leaderboardMessages = messages.filter(m => m.author.id === channel.client.user.id && m.embeds[0] && m.embeds[0].title === 'Valorant Leaderboard');
+        await Promise.all(leaderboardMessages.map(m => m.delete()));
+
+
+        // Send the new leaderboard message
         if (channel) {
             await channel.send({ embeds: [leaderboardEmbed] });
         } else {

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,8 @@ const connectDB = require('./db'); // Import connectDB
 // Connect to MongoDB
 connectDB();
 
+const leaderboardUpdateSchedule = '0 */4 * * *'; // Run every 4 hours at 0 minutes
+
 // Create a new Discord client
 const client = new Client({ 
     intents: [
@@ -72,7 +74,7 @@ client.on('messageCreate', async msg => {
 
     //Val Leaderboard
     if (msg.content.startsWith('!valleaderboard')) {
-        await handleValLeaderboard(msg);
+        await handleValLeaderboard();
     }
 
     // Message == !cleanchat
@@ -136,6 +138,11 @@ schedule.scheduleJob('* * * * *', async () => {
             await ValorantPlayer.findByIdAndUpdate(player._id, { val_lastGameID: lastGame.meta.id });
         }
     }
+});
+
+// Schedule the job to run every 4 hours
+schedule.scheduleJob(leaderboardUpdateSchedule, async () => {
+    await handleValLeaderboard();
 });
 
 


### PR DESCRIPTION
This Pull Request adds a new feature to automatically update the Valorant leaderboard every 4 hours and delete any existing leaderboard messages in the designated channel. The handleValLeaderboard() function has been modified to delete all existing leaderboard messages in the channel before sending the new one. The update schedule has been implemented using node-schedule in the index.js file. This feature should help keep the leaderboard up to date and reduce clutter in the channel.